### PR TITLE
build: revert action checkout that caused duplicate authorization header error

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - id: checkout-source-code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # 5.0.1
 
     - id: setup-Python
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
@@ -67,7 +67,7 @@ jobs:
       uses: tagdots/setup-badge-action@294661aa1f149b59dfe1cd187539eca7f8f0fabf # 1.0.18
       with:
         badge-name: coverage
-        badge-url: https://github.com/tagdots/setup-badge/actions/workflows/cron-tasks.yaml
+        badge-url: https://github.com/tagdots-dev/badge-test/actions/workflows/cron-tasks.yaml
         label: "Code Coverage"
         message: "${{ steps.get-coverage-results.outputs.COV_PER }}"
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by Terraform -->
<!-- Describe the issue -->
#### Issue Summary
_action/checkout introduced an "Duplicate header: "Authorization" error in v6+.  The scope of impact involves a multi-step job that utilizes the GitHub token._

- outstanding reported issue: https://github.com/actions/checkout/issues/2299
- logs
```
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +15ac4e68e40ef802df5c958e6c9d8cb4c12a184c:refs/remotes/origin/main
  remote: Duplicate header: "Authorization"
  Error: fatal: unable to access 'https://github.com/tagdots-dev/upc-test/': The requested URL returned error: 400
  The process '/usr/bin/git' failed with exit code 128
  Waiting 20 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +15ac4e68e40ef802df5c958e6c9d8cb4c12a184c:refs/remotes/origin/main
  remote: Duplicate header: "Authorization"
  Error: fatal: unable to access 'https://github.com/tagdots-dev/upc-test/': The requested URL returned error: 400
  The process '/usr/bin/git' failed with exit code 128
  Waiting 13 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +15ac4e68e40ef802df5c958e6c9d8cb4c12a184c:refs/remotes/origin/main
  remote: Duplicate header: "Authorization"
  Error: fatal: unable to access 'https://github.com/tagdots-dev/upc-test/': The requested URL returned error: 400
  Error: The process '/usr/bin/git' failed with exit code 128
```

<!-- What is the goal of the Pull Request? -->
#### Why was this PR created?
_This PR reverts action/checkout from v6 to v5.0.1.  If the fix is not addressed in action/checkout, the next step is to break the multi-step job into different jobs_

