### PR TITLE
build: fix duplicate header by breaking the a multi-step job into 2 jobs

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -18,12 +18,11 @@ permissions:
     pull-requests: read
 
 jobs:
-  badge-coverage: # https://github.com/tagdots/setup-badge-action
+  pre-badge-coverage:
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
-      pull-requests: write
 
     outputs:
       COV_PER: ${{ steps.get-coverage-results.outputs.COV_PER }}
@@ -63,13 +62,20 @@ jobs:
         overwrite: true
         compression-level: 6
 
+  badge-coverage: # https://github.com/tagdots/setup-badge-action
+    runs-on: ubuntu-latest
+    needs: pre-badge-coverage
+    permissions:
+      contents: write
+
+    steps:
     - id: coverage-badge
       uses: tagdots/setup-badge-action@294661aa1f149b59dfe1cd187539eca7f8f0fabf # 1.0.18
       with:
         badge-name: coverage
         badge-url: https://github.com/tagdots-dev/badge-test/actions/workflows/cron-tasks.yaml
         label: "Code Coverage"
-        message: "${{ steps.get-coverage-results.outputs.COV_PER }}"
+        message: "${{ needs.pre-badge-coverage.outputs.COV_PER }}"
 
   stale-workflow-runs: # https://github.com/tagdots/delete-workflow-runs
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![CI](https://github.com/tagdots-dev/badge-test/actions/workflows/ci.yaml/badge.svg?logo=github&labelColor=222222)](https://github.com/tagdots-dev/badge-test/actions/workflows/ci.yaml)
 [![CodeQL](https://github.com/tagdots-dev/badge-test/actions/workflows/reusable-codeql.yaml/badge.svg?logo=github&labelColor=222222)](https://github.com/tagdots-dev/badge-test/actions/workflows/reusable-codeql.yaml)
-[![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tagdots-dev/badge-test/refs/heads/badges/badges/coverage.json)](https://github.com/tagdots-dev/badge-test/actions/workflows/cron-badges.yaml)
+[![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tagdots-dev/badge-test/refs/heads/badges/badges/coverage.json)](https://github.com/tagdots-dev/badge-test/actions/workflows/cron-tasks.yaml)


### PR DESCRIPTION
<!-- NOTE: this file is managed by Terraform -->
<!-- Describe the issue -->
#### Issue Summary
_action/checkout since v6 causes duplicate header error (http status code: 400).  It is determined that both badge job runs action/checkout twice (with the second run from setup-badge-action)_


<!-- What is the goal of the Pull Request? -->
#### Why was this PR created?
Break setup-badge-action out to another job so that we don't run action/checkout twice.


